### PR TITLE
feat: advance sub-stage after invention

### DIFF
--- a/HanInventor/src/services/aiService.js
+++ b/HanInventor/src/services/aiService.js
@@ -6,11 +6,9 @@ import {
   createInventionUserPrompt,
   createQuestUserPrompt
 } from '../prompts.js';
-import { 
-  getInventionTools, 
-  getQuestTools, 
-  getQuestWithSuggestionsTools,
-  handleToolCall 
+import {
+  getInventionTools,
+  getQuestWithSuggestionsTools
 } from '../tools.js';
 
 // 使用代理路径而非直接调用外部API

--- a/HanInventor/src/services/gameState.js
+++ b/HanInventor/src/services/gameState.js
@@ -18,6 +18,8 @@ export function saveGameState(state) {
       historicalEvents: state.historicalEvents || [],
       inventionResults: state.inventionResults || {},
       currentQuest: state.currentQuest || '', // 保存当前任务
+      questQueue: state.questQueue || [], // 保存任务队列
+      currentSubStageIndex: state.currentSubStageIndex || 0, // 保存当前子阶段
       inventionSuggestions: window.currentInventionSuggestions || [], // 保存发明建议
       isInventing: state.isInventing,
       timestamp: Date.now() // 添加时间戳用于调试
@@ -74,6 +76,7 @@ export function getInitialGameState() {
       "丞相府邸传来消息，今年的蜀中雨水过多，许多农具因潮湿而加速朽坏，来年春耕恐受影响，百姓忧心忡忡。你是否能构想一种更耐久的材料，或是一种能提升耕作效率的新式农具？",
       "军医处传来简报，军士在潮湿环境下，伤口极易感染恶化，非战斗减员日益增多。寻常的布帛和草药，已难堪大用。你是否有办法创造出更有效的清创和包扎之物？"
     ],
+    currentSubStageIndex: 0,
     isInventing: false
   };
 }

--- a/HanInventor/vite.config.js
+++ b/HanInventor/vite.config.js
@@ -21,8 +21,8 @@ export default defineConfig({
         target: 'https://dashscope.aliyuncs.com',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api\/dashscope/, ''),
-        configure: (proxy, options) => {
-          proxy.on('proxyReq', (proxyReq, req, res) => {
+        configure: (proxy) => {
+          proxy.on('proxyReq', (proxyReq) => {
             // 添加必要的请求头
             proxyReq.setHeader('User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36');
           });


### PR DESCRIPTION
## Summary
- track sub-stage progression with thresholds and dedicated quest queues
- refresh quest queue and log historical sub-stage events after inventions
- persist sub-stage and quest queue data in saved game state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1c63129dc832f9b7384be2bccc46e