### PR TITLE
feat: add quest category styling

### DIFF
--- a/HanInventor/src/App.vue
+++ b/HanInventor/src/App.vue
@@ -126,7 +126,7 @@ const handleInventionCompleted = async (data) => {
 
     // 获取新的机遇任务
     try {
-      await getNewQuestTask(true);
+      await getNewQuestTask();
       console.log('发明完成后，新任务已生成');
       
       // 立即保存游戏状态，确保所有变化被持久化
@@ -190,7 +190,7 @@ const handleRequestNewQuest = async () => {
       historicalEvents.unshift(newEvent);
       
       // 获取新的机遇任务
-      await getNewQuestTask(true);
+      await getNewQuestTask();
       
       // 立即保存游戏状态，确保国力值变化和新任务被持久化
       const currentState = getCurrentGameState();
@@ -208,7 +208,7 @@ const handleRequestNewQuest = async () => {
 };
 
 // 获取新机遇任务的函数
-const getNewQuestTask = async (forceRefresh = false) => {
+const getNewQuestTask = async () => {
   try {
     currentQuest.value = '天工正在思考新的机遇...';
     const questResult = await getNewQuest(currentChapter.value);

--- a/HanInventor/src/assets/styles.css
+++ b/HanInventor/src/assets/styles.css
@@ -1,0 +1,9 @@
+.quest-basic {
+  background-color: #e6f7ff;
+  border-left: 4px solid #1890ff;
+}
+
+.quest-luxury {
+  background-color: #fffbe6;
+  border-left: 4px solid #faad14;
+}

--- a/HanInventor/src/components/QuestList.vue
+++ b/HanInventor/src/components/QuestList.vue
@@ -1,0 +1,55 @@
+<template>
+  <ul class="quest-list">
+    <li
+      v-for="(quest, index) in quests"
+      :key="quest.id || index"
+      :class="['quest-item', quest.category ? `quest-${quest.category}` : '']"
+    >
+      <span class="category-icon" v-if="quest.category">{{ getIcon(quest.category) }}</span>
+      <span class="quest-text">{{ quest.title || quest }}</span>
+    </li>
+  </ul>
+</template>
+
+<script setup>
+defineProps({
+  quests: {
+    type: Array,
+    default: () => []
+  }
+})
+
+function getIcon(category) {
+  if (category === 'luxury') {
+    return '💎'
+  }
+  if (category === 'basic') {
+    return '🔰'
+  }
+  return ''
+}
+</script>
+
+<style scoped>
+.quest-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.quest-item {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  border-radius: 4px;
+}
+
+.category-icon {
+  margin-right: 8px;
+}
+
+.quest-text {
+  flex: 1;
+}
+</style>

--- a/HanInventor/src/main.js
+++ b/HanInventor/src/main.js
@@ -3,6 +3,7 @@ import { createPinia } from 'pinia'
 
 import App from './App.vue'
 import router from './router'
+import './assets/styles.css'
 
 const app = createApp(App)
 

--- a/HanInventor/src/services/aiService.js
+++ b/HanInventor/src/services/aiService.js
@@ -6,11 +6,9 @@ import {
   createInventionUserPrompt,
   createQuestUserPrompt
 } from '../prompts.js';
-import { 
-  getInventionTools, 
-  getQuestTools, 
-  getQuestWithSuggestionsTools,
-  handleToolCall 
+import {
+  getInventionTools,
+  getQuestWithSuggestionsTools
 } from '../tools.js';
 
 // 使用代理路径而非直接调用外部API

--- a/HanInventor/vite.config.js
+++ b/HanInventor/vite.config.js
@@ -21,8 +21,8 @@ export default defineConfig({
         target: 'https://dashscope.aliyuncs.com',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api\/dashscope/, ''),
-        configure: (proxy, options) => {
-          proxy.on('proxyReq', (proxyReq, req, res) => {
+        configure: (proxy) => {
+          proxy.on('proxyReq', (proxyReq) => {
             // 添加必要的请求头
             proxyReq.setHeader('User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36');
           });


### PR DESCRIPTION
## Summary
- add QuestList component with category icons per quest
- style basic and luxury quests via new global CSS classes
- load global styles in main entry and clean unused variables for lint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1c62d8d2c832f824e359f7a47066c