### PR TITLE
Replace emoji icons with SVGs

### DIFF
--- a/HanInventor/public/icons/fireworks.svg
+++ b/HanInventor/public/icons/fireworks.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#8b4513" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="12" y1="2" x2="12" y2="22"/>
+  <line x1="2" y1="12" x2="22" y2="12"/>
+  <line x1="4.9" y1="4.9" x2="19.1" y2="19.1"/>
+  <line x1="19.1" y1="4.9" x2="4.9" y2="19.1"/>
+</svg>

--- a/HanInventor/public/icons/quest.svg
+++ b/HanInventor/public/icons/quest.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#8b4513" stroke="#8b4513" stroke-width="1" stroke-linejoin="round">
+  <path d="M12 2l3 6 7 .5-5 4.5 1.5 7-6-3.5-6 3.5 1.5-7-5-4.5 7-.5z"/>
+</svg>

--- a/HanInventor/public/icons/restart.svg
+++ b/HanInventor/public/icons/restart.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#8b4513" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 12a9 9 0 1 0 9-9v3L8 3l4-4" transform="translate(0,1)"/>
+</svg>

--- a/HanInventor/public/icons/scroll.svg
+++ b/HanInventor/public/icons/scroll.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#8b4513" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 4h13a2 2 0 0 1 2 2v10a2 2 0 0 0 0 4H7a2 2 0 0 1 0-4h11V6H5a1 1 0 0 0-1 1v11"/>
+</svg>

--- a/HanInventor/src/components/InventionWorkbench.vue
+++ b/HanInventor/src/components/InventionWorkbench.vue
@@ -5,7 +5,10 @@
     <!-- 当前机遇任务显示 -->
     <div v-if="currentQuest" class="current-quest">
       <div class="quest-header">
-        <h3>📜 当前机遇</h3>
+        <h3>
+          <img src="/icons/scroll.svg" alt="机遇" class="icon" />
+          当前机遇
+        </h3>
         <button @click="requestNewQuest" class="new-quest-btn" :disabled="isRequestingNewQuest">
           {{ isRequestingNewQuest ? '思考中...' : '获取新机遇' }}
         </button>
@@ -93,7 +96,10 @@
       <!-- 对话完成提示 -->
       <div v-if="isConversationComplete" class="completion-area">
         <div class="completion-message">
-          <h3>🎉 发明方案已完善！</h3>
+          <h3>
+            <img src="/icons/fireworks.svg" alt="完成" class="icon" />
+            发明方案已完善！
+          </h3>
           <p>AI天工已收集到足够的信息，正在为您生成最终的发明方案...</p>
         </div>
         <button @click="generateFinalInvention" :disabled="isGenerating" class="generate-btn">
@@ -466,6 +472,13 @@ export default {
 </script>
 
 <style scoped>
+.icon {
+  width: 1.2em;
+  height: 1.2em;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
 .invention-workbench {
   padding: 20px;
   border: 2px solid #8B4513;

--- a/HanInventor/src/components/NarrativeDisplay.vue
+++ b/HanInventor/src/components/NarrativeDisplay.vue
@@ -23,10 +23,16 @@ const extractPowerIncrease = (event) => {
 
 <template>
   <div class="narrative-display">
-    <h2>📜 发明成果与历史记录</h2>
+    <h2>
+      <img src="/icons/scroll.svg" alt="记录" class="icon" />
+      发明成果与历史记录
+    </h2>
     
     <div v-if="props.events.length === 0" class="no-events">
-      <p>🌟 等待您的第一个发明成果...</p>
+      <p>
+        <img src="/icons/quest.svg" alt="等待" class="icon" />
+        等待您的第一个发明成果...
+      </p>
     </div>
     
     <div v-else class="events-container">
@@ -50,6 +56,13 @@ const extractPowerIncrease = (event) => {
 </template>
 
 <style scoped>
+.icon {
+  width: 1.2em;
+  height: 1.2em;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
 .narrative-display {
   background-color: #f5f5dc;
   border-radius: 8px;

--- a/HanInventor/src/components/StatusDisplay.vue
+++ b/HanInventor/src/components/StatusDisplay.vue
@@ -31,7 +31,8 @@ const progressPercentage = computed(() => {
     <div class="status-header">
       <h1>{{ currentChapter }} - 匡扶汉室的发明家</h1>
       <button @click="emit('restart-game')" class="restart-btn" title="重新开始游戏">
-        🔄 重新开始
+        <img src="/icons/restart.svg" alt="重新开始" class="icon" />
+        重新开始
       </button>
     </div>
     
@@ -49,6 +50,13 @@ const progressPercentage = computed(() => {
 </template>
 
 <style scoped>
+.icon {
+  width: 1.2em;
+  height: 1.2em;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
 .status-display {
   background: linear-gradient(135deg, #8B4513 0%, #A0522D 100%);
   color: white;


### PR DESCRIPTION
## Summary
- add hand-drawn scroll, fireworks, quest and restart SVG icons
- swap emoji in workbench, narrative and status components for new SVG icons
- introduce shared `.icon` styling for consistent size and alignment

## Testing
- `npm run lint` *(fails: 'forceRefresh' is assigned a value but never used, and other unused variable errors)*
- `npx eslint src/components/InventionWorkbench.vue src/components/NarrativeDisplay.vue src/components/StatusDisplay.vue`

------
https://chatgpt.com/codex/tasks/task_e_68a1c61e48c8832fb4ce7b35347d2c12