### PR TITLE
feat: add Chinese calligraphy fonts

### DIFF
--- a/HanInventor/index.html
+++ b/HanInventor/index.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Vite App</title>
+    <link rel="preload" href="/fonts/fangsong.ttf" as="font" type="font/ttf" crossorigin>
+    <link rel="preload" href="/fonts/xingkai.ttf" as="font" type="font/ttf" crossorigin>
+    <title>蜀汉天工</title>
   </head>
   <body>
     <div id="app"></div>

--- a/HanInventor/public/fonts/fangsong.ttf
+++ b/HanInventor/public/fonts/fangsong.ttf
@@ -1,0 +1,1 @@
+placeholder

--- a/HanInventor/public/fonts/xingkai.ttf
+++ b/HanInventor/public/fonts/xingkai.ttf
@@ -1,0 +1,1 @@
+placeholder

--- a/HanInventor/src/assets/global.css
+++ b/HanInventor/src/assets/global.css
@@ -1,0 +1,17 @@
+@font-face {
+  font-family: 'FangSong';
+  src: url('/fonts/fangsong.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'XingKai';
+  src: url('/fonts/xingkai.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}
+
+body {
+  font-family: 'FangSong', '楷体', serif;
+}

--- a/HanInventor/src/main.js
+++ b/HanInventor/src/main.js
@@ -2,6 +2,7 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 
 import App from './App.vue'
+import './assets/global.css'
 import router from './router'
 
 const app = createApp(App)


### PR DESCRIPTION
## Summary
- add placeholder FangSong and XingKai fonts under public/fonts
- load custom fonts and rename page title to 蜀汉天工
- introduce global font styles and import in main entry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c60e05e0832facdc1126711a636d